### PR TITLE
Add Email Checking

### DIFF
--- a/api/v1/users.php
+++ b/api/v1/users.php
@@ -60,6 +60,25 @@ function validateCanCreateUser($proposedUser, $auth, &$message)
     return true;
 }
 
+function validEmail($email)
+{
+    if(filter_var($email) === false)
+    {
+        return false;
+    }
+    $pos = strpos($email, '@');
+    if($pos === false)
+    {
+        return false;
+    }
+    $domain = substr($email, $pos+1);
+    if(checkdnsrr($domain, 'MX') === false)
+    {
+        return false;
+    }
+    return true;
+}
+
 function create_user()
 {
     global $app;
@@ -92,6 +111,11 @@ function create_user()
     if(validateCanCreateUser($obj, $auth, $message) === false)
     {
         echo json_encode(array('res'=>false, 'message'=>$message));
+        return;
+    }
+    else if(validEmail($obj->mail) === false)
+    {
+        echo json_encode(array('res'=>false, 'message'=>'Invalid Email Address!'));
         return;
     }
     $ret = $auth->createPendingUser($obj);

--- a/test/UserTest.php
+++ b/test/UserTest.php
@@ -1,0 +1,32 @@
+<?php
+//require_once(dirname(__FILE__).'/../api/v1/users.php');
+
+function validEmail($email)
+{
+    if(filter_var($email) === false)
+    {
+        return false;
+    }
+    $pos = strpos($email, '@');
+    if($pos === false)
+    {
+        return false;
+    }
+    $domain = substr($email, $pos+1);
+    if(checkdnsrr($domain, 'MX') === false)
+    {
+        return false;
+    }
+    return true;
+}
+
+class UserTest extends PHPUnit_Framework_TestCase
+{
+    public function testEmailFunction()
+    {
+        $this->assertTrue(validEmail('test@test.com'));
+        $this->assertFalse(validEmail('test@test'));
+        $this->assertFalse(validEmail('test@gmail.x'));
+    }
+}
+/* vim: set tabstop=4 shiftwidth=4 expandtab: */


### PR DESCRIPTION
This adds checks to the backed (in addition to the front end checks) to make sure the email address appears valid to PHP, contains an @ symbol, and the domain has an MX record. This should help cut down on bad registrations. 