### PR TITLE
allow options request for login

### DIFF
--- a/api/v1/class.ProfilesAPI.php
+++ b/api/v1/class.ProfilesAPI.php
@@ -3,9 +3,16 @@ class ProfilesAPI extends Http\Rest\RestAPI
 {
     public function setup($app)
     {
+        $app->options('/login[/]', array($this, 'options'));
         $app->post('/login[/]', array($this, 'login'));
         $app->post('/logout[/]', array($this, 'logout'));
         $app->post('/zip[/]', array($this, 'validateZip'));
+
+    }
+
+    public function options($request, $response)
+    {
+      return $response->withJson(true);
     }
 
     public function login($request, $response)
@@ -98,3 +105,4 @@ class ProfilesAPI extends Http\Rest\RestAPI
     }
 }
 /* vim: set tabstop=4 shiftwidth=4 expandtab: */
+


### PR DESCRIPTION
I submit this for review and discussion only

the idea is that all API endpoints should support options requests.
the changes in this PR were what was required to enable this for the login endpoint
defining an options response for every single endpoint seems soggy..

thoughts on a more elegant approach:

1. define a generic response handler in \HTTP\REST\RestAPI
`public function optionsResponse($request, $response) { return $response->withJson(true); }`
options responses are generally expected to return an empty body with CORS headers.
the addition of expected headers is already handled by `\HTTP\REST\CORSMiddleware`

2. overload `map`, `get`, `post`, `put`, and `delete` method calls in \Http\WebSite  
to allow automatic defining of `options` method responses
which are handled by the generic `optionsResponse` handler
